### PR TITLE
    chip-tool now builds the core as a static library (chip-tool-utils)

### DIFF
--- a/examples/chip-tool/BUILD.gn
+++ b/examples/chip-tool/BUILD.gn
@@ -29,7 +29,19 @@ declare_args() {
   config_pair_with_random_id = true
 }
 
-executable("chip-tool") {
+config("config") {
+  include_dirs = [
+    ".",
+    "${chip_root}/zzz_generated/chip-tool",
+  ]
+
+  defines = [
+    "CONFIG_USE_SEPARATE_EVENTLOOP=${config_use_separate_eventloop}",
+    "CONFIG_PAIR_WITH_RANDOM_ID=${config_pair_with_random_id}",
+  ]
+}
+
+static_library("chip-tool-utils") {
   sources = [
     "commands/clusters/ModelCommand.cpp",
     "commands/common/Command.cpp",
@@ -43,12 +55,6 @@ executable("chip-tool") {
     "commands/reporting/ReportingCommand.cpp",
     "commands/tests/TestCommand.cpp",
     "config/PersistentStorage.cpp",
-    "main.cpp",
-  ]
-
-  defines = [
-    "CONFIG_USE_SEPARATE_EVENTLOOP=${config_use_separate_eventloop}",
-    "CONFIG_PAIR_WITH_RANDOM_ID=${config_pair_with_random_id}",
   ]
 
   deps = [
@@ -60,10 +66,27 @@ executable("chip-tool") {
 
   cflags = [ "-Wconversion" ]
 
-  include_dirs = [
-    ".",
-    "${chip_root}/zzz_generated/chip-tool",
+  public_configs = [ ":config" ]
+
+  output_dir = root_out_dir
+}
+
+executable("chip-tool") {
+  sources = [
+    "main.cpp",
   ]
+
+  deps = [
+    ":chip-tool-utils",
+    "${chip_root}/src/controller/data_model",
+    "${chip_root}/src/lib",
+    "${chip_root}/src/platform",
+    "${chip_root}/third_party/inipp",
+  ]
+
+  cflags = [ "-Wconversion" ]
+
+  public_configs = [ ":config" ]
 
   output_dir = root_out_dir
 }

--- a/examples/chip-tool/commands/common/Command.h
+++ b/examples/chip-tool/commands/common/Command.h
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include "controller/ExampleOperationalCredentialsIssuer.h"
+#include "controller/OperationalCredentialsDelegate.h"
 #include <controller/CHIPDeviceController.h>
 #include <inet/InetInterface.h>
 #include <lib/support/Span.h>
@@ -100,7 +100,7 @@ public:
     struct ExecutionContext
     {
         ChipDeviceCommissioner * commissioner;
-        chip::Controller::ExampleOperationalCredentialsIssuer * opCredsIssuer;
+        chip::Controller::OperationalCredentialsDelegate * opCredsIssuer;
         PersistentStorage * storage;
         chip::NodeId localId;
         chip::NodeId remoteId;

--- a/examples/chip-tool/commands/common/Commands.h
+++ b/examples/chip-tool/commands/common/Commands.h
@@ -20,17 +20,21 @@
 
 #include "../../config/PersistentStorage.h"
 #include "Command.h"
-#include <controller/ExampleOperationalCredentialsIssuer.h>
+#include <controller/OperationalCredentialsDelegate.h>
+#include <crypto/CHIPCryptoPAL.h>
 #include <map>
 
 class Commands
 {
 public:
     using NodeId         = ::chip::NodeId;
+    using FabricId       = ::chip::FabricId;
     using CommandsVector = ::std::vector<std::unique_ptr<Command>>;
 
     void Register(const char * clusterName, commands_list commandsList);
     int Run(int argc, char ** argv);
+
+    virtual ~Commands() {}
 
 private:
     // *ranCommand will be set to the command we ran if we get as far as running
@@ -48,8 +52,14 @@ private:
     void ShowClusterAttributes(std::string executable, std::string clusterName, std::string commandName, CommandsVector & commands);
     void ShowCommand(std::string executable, std::string clusterName, Command * command);
 
+    virtual CHIP_ERROR InitializeCredentialsIssuer(chip::PersistentStorageDelegate & storage) = 0;
+    virtual CHIP_ERROR SetupDeviceAttestation()                                               = 0;
+    virtual chip::Controller::OperationalCredentialsDelegate * GetCredentialIssuer()          = 0;
+    virtual CHIP_ERROR GenerateControllerNOCChain(NodeId nodeId, FabricId fabricId, chip::Crypto::P256Keypair & keypair,
+                                                  chip::MutableByteSpan & rcac, chip::MutableByteSpan & icac,
+                                                  chip::MutableByteSpan & noc)                = 0;
+
     std::map<std::string, CommandsVector> mClusters;
     chip::Controller::DeviceCommissioner mController;
-    chip::Controller::ExampleOperationalCredentialsIssuer mOpCredsIssuer;
     PersistentStorage mStorage;
 };

--- a/examples/chip-tool/commands/example/ExampleCredentialIssuerCommands.h
+++ b/examples/chip-tool/commands/example/ExampleCredentialIssuerCommands.h
@@ -1,0 +1,50 @@
+/*
+ *   Copyright (c) 2021 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#pragma once
+
+#include <commands/common/Commands.h>
+#include <controller/ExampleOperationalCredentialsIssuer.h>
+#include <credentials/DeviceAttestationCredsProvider.h>
+#include <credentials/DeviceAttestationVerifier.h>
+#include <credentials/examples/DeviceAttestationCredsExample.h>
+#include <credentials/examples/DeviceAttestationVerifierExample.h>
+
+class ExampleCredentialIssuerCommands : public Commands
+{
+private:
+    CHIP_ERROR InitializeCredentialsIssuer(chip::PersistentStorageDelegate & storage) override
+    {
+        return mOpCredsIssuer.Initialize(storage);
+    }
+    CHIP_ERROR SetupDeviceAttestation() override
+    {
+        chip::Credentials::SetDeviceAttestationCredentialsProvider(chip::Credentials::Examples::GetExampleDACProvider());
+        chip::Credentials::SetDeviceAttestationVerifier(chip::Credentials::Examples::GetExampleDACVerifier());
+        return CHIP_NO_ERROR;
+    }
+    chip::Controller::OperationalCredentialsDelegate * GetCredentialIssuer() override { return &mOpCredsIssuer; }
+    CHIP_ERROR GenerateControllerNOCChain(NodeId nodeId, FabricId fabricId, chip::Crypto::P256Keypair & keypair,
+                                          chip::MutableByteSpan & rcac, chip::MutableByteSpan & icac,
+                                          chip::MutableByteSpan & noc) override
+    {
+        return mOpCredsIssuer.GenerateNOCChainAfterValidation(nodeId, fabricId, keypair.Pubkey(), rcac, icac, noc);
+    }
+
+    chip::Controller::ExampleOperationalCredentialsIssuer mOpCredsIssuer;
+};

--- a/examples/chip-tool/main.cpp
+++ b/examples/chip-tool/main.cpp
@@ -16,7 +16,7 @@
  *
  */
 
-#include "commands/common/Commands.h"
+#include "commands/example/ExampleCredentialIssuerCommands.h"
 
 #include "commands/discover/Commands.h"
 #include "commands/pairing/Commands.h"
@@ -31,7 +31,7 @@
 // ================================================================================
 int main(int argc, char * argv[])
 {
-    Commands commands;
+    ExampleCredentialIssuerCommands commands;
     registerCommandsDiscover(commands);
     registerCommandsPayload(commands);
     registerCommandsPairing(commands);

--- a/src/controller/CHIPDevice.h
+++ b/src/controller/CHIPDevice.h
@@ -398,6 +398,7 @@ public:
     }
 
     ByteSpan GetCSRNonce() const { return ByteSpan(mCSRNonce, sizeof(mCSRNonce)); }
+    MutableByteSpan GetCSRNonce() { return MutableByteSpan(mCSRNonce, sizeof(mCSRNonce)); }
 
     CHIP_ERROR SetAttestationNonce(ByteSpan attestationNonce)
     {

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1274,6 +1274,8 @@ CHIP_ERROR DeviceCommissioner::SendOperationalCertificateSigningRequestCommand(D
     Callback::Cancelable * successCallback = mOpCSRResponseCallback.Cancel();
     Callback::Cancelable * failureCallback = mOnCSRFailureCallback.Cancel();
 
+    MutableByteSpan csrNonce = device->GetCSRNonce();
+    ReturnErrorOnFailure(mOperationalCredentialsDelegate->GenerateNOCSR(csrNonce));
     ReturnErrorOnFailure(cluster.OpCSRRequest(successCallback, failureCallback, device->GetCSRNonce()));
 
     ChipLogDetail(Controller, "Sent OpCSR request, waiting for the CSR");
@@ -1379,7 +1381,7 @@ CHIP_ERROR DeviceCommissioner::ProcessOpCSR(const ByteSpan & NOCSRElements, cons
     mOperationalCredentialsDelegate->SetNodeIdForNextNOCRequest(device->GetDeviceId());
     mOperationalCredentialsDelegate->SetFabricIdForNextNOCRequest(0);
 
-    return mOperationalCredentialsDelegate->GenerateNOCChain(NOCSRElements, AttestationSignature, ByteSpan(), ByteSpan(),
+    return mOperationalCredentialsDelegate->GenerateNOCChain(NOCSRElements, AttestationSignature, device->GetDAC(), ByteSpan(),
                                                              ByteSpan(), &mDeviceNOCChainCallback);
 }
 

--- a/src/controller/OperationalCredentialsDelegate.h
+++ b/src/controller/OperationalCredentialsDelegate.h
@@ -76,6 +76,12 @@ public:
      *   fabric ID.
      */
     virtual void SetFabricIdForNextNOCRequest(FabricId fabricId) {}
+
+    virtual CHIP_ERROR GenerateNOCSR(MutableByteSpan & csrNonce)
+    {
+        ReturnErrorOnFailure(Crypto::DRBG_get_bytes(csrNonce.data(), csrNonce.size()));
+        return CHIP_NO_ERROR;
+    }
 };
 
 } // namespace Controller


### PR DESCRIPTION
    Added set of pure virtual methods PKI-related to Commands class
    Added example implementation of Matter’s example PKI
    Added DAC to GenerateNOCChain method call
    Added GenerateNOCSR method to OperationalCredentialsDelegate class so every PKI-vendor can override the nonce generation to follow a custom set of rules. Random example added.

#### Problem
What is being fixed?  Examples:
* Fix crash on startup
* Fixes #12345 Frobnozzle is leaky (exactly like that, so GitHub will auto-close the issue).

#### Change overview
What's in this PR

#### Testing
How was this tested? (at least one bullet point required)
* If unit tests were added, how do they cover this issue?
* If unit tests existed, how were they fixed/modified to prevent this in future?
* If new unit tests are not added, why not?
* If integration tests were added, how do they verify this change?
* If new integration tests are not added, why not?
* If manually tested, what platforms controller and device platforms were manually tested, and how?
* If no testing is required, why not?
